### PR TITLE
Status check timeout

### DIFF
--- a/server.js
+++ b/server.js
@@ -23,35 +23,35 @@ module.exports = function (dir, opts, cb) {
 
   app.on('/add', function (req, res, ctx) {
     api.add(req, res, ctx, function (err, code, data) {
-      if (err) return app.error(res, code, err.message)
+      if (err) return app.error(code, err.message).pipe(res)
       app.send(code, data).pipe(res)
     })
   })
 
   app.on('/remove', function (req, res, ctx) {
     api.remove(req, res, ctx, function (err, code, data) {
-      if (err) return app.error(res, code, err.message)
+      if (err) return app.error(code, err.message).pipe(res)
       app.send(code, data).pipe(res)
     })
   })
 
   app.on('/progress/:key', function (req, res, ctx) {
     api.archiveProgress(req, res, ctx, function (err, code, data) {
-      if (err) return app.error(res, code, err.message)
+      if (err) return app.error(code, err.message).pipe(res)
       app.send(code, data).pipe(res)
     })
   })
 
   app.on('/status', function (req, res, ctx) {
     api.status(req, res, ctx, function (err, code, data) {
-      if (err) return app.error(res, code, err.message)
+      if (err) return app.error(code, err.message).pipe(res)
       app.send(code, data).pipe(res)
     })
   })
 
   app.on('/status/:key', function (req, res, ctx) {
     api.status(req, res, ctx, function (err, code, data) {
-      if (err) return app.error(res, code, err.message)
+      if (err) return app.error(code, err.message).pipe(res)
       app.send(code, data).pipe(res)
     })
   })


### PR DESCRIPTION
If an archive has been added to the server, but none of the data has been synced yet, it's possible that the calls to fetch info about the archiver will not ever complete. This PR makes a 408 timeout response happen instead.

This should ultimately be handled higher up in the stack. See https://github.com/mafintosh/hypercore/issues/52